### PR TITLE
Simplify Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,22 +2,6 @@ FROM python:3-alpine
 
 ENV AWSCLI_VERSION='1.17.0'
 
-LABEL "version"="${AWSCLI_VERSION}"
-LABEL "com.github.actions.name"="AWS CLI"
-LABEL "com.github.actions.description"="GitHub Action for AWS CLI"
-LABEL "com.github.actions.icon"="cloud"
-LABEL "com.github.actions.color"="green"
-
-RUN apk -v --update add \
-        groff \
-        && \
-    apk -v --purge del py-pip && \
-    rm /var/cache/apk/*
-
-RUN pip install --quiet --no-cache-dir awscli==${AWSCLI_VERSION}
-
-VOLUME /root/.aws
-VOLUME /project
-WORKDIR /project
+RUN pip3 --no-cache-dir install awscli==${AWSCLI_VERSION}
 
 ENTRYPOINT ["aws"]


### PR DESCRIPTION
* Don't pin a specific AWS CLI version (1.18 is already out, and having
  to update the Dockerfile to support newer CLI features will get old
  fast)
* Don't run any apk commands. They aren't needed.
* Remove legacy (GitHub Actions v1) Docker label metadata.

This shaves about 10sec off image build time.