### PR TITLE
feat(output): expose stdout as result

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
 FROM python:3-alpine
 
+COPY entrypoint.sh /
+
 ENV AWSCLI_VERSION='1.17.0'
 
 RUN pip3 --no-cache-dir install awscli==${AWSCLI_VERSION}
 
-ENTRYPOINT ["aws"]
+ENTRYPOINT ["/bin/sh", "/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -4,11 +4,31 @@ Docker image for AWS CLI, also source for the AWS CLI GitHub Action.
 
 ## Example Usage
 
-```
+```yaml
 - name: S3 Sync
   uses: ItsKarma/aws-cli@v1.70.0
   with:
     args: s3 sync --delete --acl public-read localdir/ s3://remote-bucket/
+  env:
+    AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+    AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    AWS_DEFAULT_REGION: "us-east-1"
+```
+
+## Output
+
+This GitHub action exposes stdout as an output named `result`. For example, in the following example, this step will
+provide an output variable at the path `steps.latest_lambda_version.outputs.result`:
+
+```yaml
+
+- name: Get latest topper compile version
+  uses: ItsKarma/aws-cli@v1.70.0
+  id: latest_lambda_version
+  with:
+    args: lambda list-versions-by-function --function-name my_function_name \
+      --no-paginate \
+      --query "max_by(Versions, &to_number(to_number(Version) || '0')).Version"
   env:
     AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
     AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Store stdout from the aws-cli call into a variable
+RESULT=$(aws "$@")
+
+# Export the variable as an output result named "result"
+echo "::set-output name=result::$RESULT"


### PR DESCRIPTION
I needed to use the aws-cli to load the latest lambda version and this action didn't provide an output. So this should work!