### PR TITLE
Fix cannot import collections.MutableMapping

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3-alpine
+FROM python:3.9-alpine
 
 ENV AWSCLI_VERSION='1.17.0'
 


### PR DESCRIPTION
We found occur error when import. `MutableMapping`
```
Traceback (most recent call last):
  File "/usr/local/bin/aws", line 27, in <module>
    sys.exit(main())
  File "/usr/local/bin/aws", line 23, in main
    return awscli.clidriver.main()
  File "/usr/local/lib/python3.10/site-packages/awscli/clidriver.py", line 68, in main
    driver = create_clidriver()
  File "/usr/local/lib/python3.10/site-packages/awscli/clidriver.py", line 77, in create_clidriver
    load_plugins(session.full_config.get('plugins', {}),
  File "/usr/local/lib/python3.10/site-packages/awscli/plugin.py", line 44, in load_plugins
    modules = _import_plugins(plugin_mapping)
  File "/usr/local/lib/python3.10/site-packages/awscli/plugin.py", line 61, in _import_plugins
    module = __import__(path, fromlist=[module])
  File "/usr/local/lib/python3.10/site-packages/awscli/handlers.py", line 42, in <module>
    from awscli.customizations.history import register_history_mode
  File "/usr/local/lib/python3.10/site-packages/awscli/customizations/history/__init__.py", line 24, in <module>
    from awscli.customizations.history.db import DatabaseConnection
  File "/usr/local/lib/python3.10/site-packages/awscli/customizations/history/db.py", line 19, in <module>
    from collections import MutableMapping
ImportError: cannot import name 'MutableMapping' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)
```

Root cause is re-located `MutableMapping` python 3.10.x. So I changed python docker image 3.9x.